### PR TITLE
Cache FQDN for cloud systems

### DIFF
--- a/bashrc.sh
+++ b/bashrc.sh
@@ -115,13 +115,14 @@ fi
 
 #HOST_COLOR=${UGreen}
 
+FQDN=`hostname -f`
 function __makeTerminalTitle() {
     local title=''
 
     local CURRENT_DIR="${PWD/#$HOME/\~}"
 
     if [ -n "${SSH_CONNECTION}" ]; then
-        title+="`hostname`:${CURRENT_DIR} [`whoami`@`hostname -f`]"
+        title+="`hostname`:${CURRENT_DIR} [`whoami`@${FQDN}]"
     else
         title+="${CURRENT_DIR} [`whoami`]"
     fi


### PR DESCRIPTION
On some (maybe badly configured) cloud systems, hostname -f may take a long time (close to a second). 

This fix caches it into a variable and re-uses it each time `$PS1` is printed.